### PR TITLE
📖 Chương 14: Truyện cười Đông Nam Á (20 truyện)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Ngày 7 - 2026-04-21
 
+### 📖 Chương 14: Truyện Cười Đông Nam Á (Issue #16)
+- Tổng hợp và Việt hóa **20 truyện cười Đông Nam Á** (Thái Lan, Philippines, Indonesia, Singapore, Malaysia, Myanmar, Việt Nam)
+- Chủ đề: xe máy vạn năng, nụ cười Thái, bão Philippines, kẹt xe Jakarta, ăn cay, phạt Singapore, durian, karaoke, Grab/Gojek, nước mắm, Songkran, ASEAN họp mặt
+- **20/20 truyện đạt** (≥ 30/40), **15 truyện ⭐** (≥ 35/40), **0 loại**
+- Điểm trung bình: 35.3/40
+- Truyện hay nhất: "Xe máy Đông Nam Á" (38/40) — chở cả gia đình + tủ lạnh trên 1 xe máy
+- Cập nhật `metadata/scoring-log.md`
+
 ### 📖 Chương 09: Truyện Cười Ấn Độ (Issue #15)
 - Tổng hợp và Việt hóa **20 truyện cười Ấn Độ**
 - Chủ đề: truyện Birbal cổ điển, đám cưới sắp đặt, IT support, gia đình đông đúc, cricket, Bollywood, cà ri, xe lửa, head wobble, chọn nghề, jugaad

--- a/metadata/scoring-log.md
+++ b/metadata/scoring-log.md
@@ -322,6 +322,40 @@ Mỗi truyện được chấm theo 4 tiêu chí, mỗi tiêu chí tối đa 10 
 
 ---
 
+## Chương 14: Truyện Cười Đông Nam Á — Ngày 2026-04-21
+
+| # | Tên truyện | Bất ngờ | Phù hợp VN | Dễ hiểu | Kể lại | Tổng | Đạt? |
+|---|-----------|---------|------------|---------|--------|------|------|
+| 1 | Xe máy Đông Nam Á — Phương tiện vạn năng | 10 | 10 | 9 | 9 | 38 | ⭐ |
+| 2 | Thái Lan — Xứ sở nụ cười | 9 | 9 | 10 | 9 | 37 | ⭐ |
+| 3 | Philippines — Bão cũng phải vui | 9 | 9 | 10 | 9 | 37 | ⭐ |
+| 4 | Indonesia — Đất nước vạn đảo | 9 | 9 | 9 | 8 | 35 | ⭐ |
+| 5 | Ăn cay — Cuộc chiến Đông Nam Á | 9 | 10 | 9 | 8 | 36 | ⭐ |
+| 6 | Singapore — Phạt là nghệ thuật | 9 | 9 | 9 | 9 | 36 | ⭐ |
+| 7 | Malaysia — Đa văn hóa ẩm thực | 8 | 9 | 9 | 8 | 34 | ✅ |
+| 8 | Myanmar — Nhẫn nại là siêu năng lực | 8 | 8 | 9 | 8 | 33 | ✅ |
+| 9 | Thời tiết Đông Nam Á — Hai mùa | 9 | 9 | 9 | 8 | 35 | ⭐ |
+| 10 | Karaoke — Tôn giáo Đông Nam Á | 9 | 10 | 9 | 8 | 36 | ⭐ |
+| 11 | Grab/Gojek — Siêu anh hùng ĐNÁ | 9 | 9 | 9 | 8 | 35 | ⭐ |
+| 12 | Thái Lan — Đất nước sabai sabai | 8 | 8 | 9 | 8 | 33 | ✅ |
+| 13 | Durian — Vua trái cây gây chia rẽ | 9 | 9 | 9 | 9 | 36 | ⭐ |
+| 14 | Giao thông ĐNÁ — Luật bất thành văn | 9 | 10 | 9 | 7 | 35 | ⭐ |
+| 15 | Philippines — Tiếng Anh nửa mùa | 8 | 8 | 9 | 9 | 34 | ✅ |
+| 16 | Nước mắm — Vũ khí bí mật VN | 9 | 10 | 9 | 9 | 37 | ⭐ |
+| 17 | Tết Songkran — Lễ hội té nước | 9 | 9 | 9 | 8 | 35 | ⭐ |
+| 18 | Cà phê Đông Nam Á | 8 | 9 | 9 | 8 | 34 | ✅ |
+| 19 | Xe tuk-tuk và giá du khách | 9 | 9 | 9 | 8 | 35 | ⭐ |
+| 20 | Đông Nam Á — Khi cả khu vực họp mặt | 9 | 10 | 9 | 9 | 37 | ⭐ |
+
+### Thống kê
+- **Tổng truyện đánh giá:** 20
+- **Đạt (≥ 30):** 20 truyện
+- **Hay đặc biệt ⭐ (≥ 35):** 15 truyện
+- **Loại ❌ (< 30):** 0 truyện
+- **Điểm trung bình (truyện đạt):** 35.3/40
+
+---
+
 ## Chương 09: Truyện Cười Ấn Độ — Ngày 2026-04-21
 
 | # | Tên truyện | Bất ngờ | Phù hợp VN | Dễ hiểu | Kể lại | Tổng | Đạt? |

--- a/sach/14-truyen-cuoi-dong-nam-a.md
+++ b/sach/14-truyen-cuoi-dong-nam-a.md
@@ -1,9 +1,575 @@
 # Chương 14: Truyện Cười Đông Nam Á 🌏
 
-> *"Placeholder - Sẽ được bổ sung nội dung"*
+> *"Ở Đông Nam Á, cười là cách rẻ nhất để sống sót qua mùa nóng."* — Khuyết danh
 
-**Về nền hài kịch Đông Nam Á:** Humor gần gũi nhất với Việt Nam, từ Thái Lan, Philippines, Indonesia, Malaysia, Myanmar. Truyện về thời tiết nóng, ăn cay, xe máy và cuộc sống hàng ngày.
+## Về nền hài kịch Đông Nam Á
+
+Đông Nam Á — vùng đất nắng nóng, xe máy, ăn cay, và tinh thần "sabai sabai" (thư thả, kệ đi). Từ Thái Lan với humor duyên dáng, Philippines với khả năng tự trào đỉnh cao, Indonesia với truyện cười dân gian phong phú, đến Malaysia và Singapore với sự pha trộn đa văn hóa — tất cả đều chia sẻ tinh thần lạc quan giữa nghịch cảnh. Đây là chương gần gũi nhất với người Việt vì chung khí hậu, chung xe máy, chung nỗi khổ tắc đường, và chung triết lý "cười cho qua ngày."
 
 ---
 
-📊 **Thống kê chương:** 0 truyện | Điểm trung bình: --/50 | Truyện ⭐: 0
+### 1. Xe máy Đông Nam Á — Phương tiện vạn năng 🏍️
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 38/40
+
+Ở Tây phương, xe máy chở tối đa 2 người.
+
+Ở Đông Nam Á:
+
+— Thái Lan: 1 xe máy chở 4 người + 2 con chó + 1 giỏ trái cây 🐕
+
+— Indonesia: 1 xe máy chở 5 người (2 em bé ngồi trước, 3 người lớn ngồi sau) 👶
+
+— Philippines: 1 xe máy chở gia đình 6 người + tivi 42 inch 📺
+
+— Việt Nam: 1 xe máy chở 3 người + 2 cây mai ngày Tết + 1 tủ lạnh 😎
+
+Du khách phương Tây chứng kiến, gọi điện về nhà:
+
+— Em ơi, bên này xe máy là xe BUS mini!
+
+> 😂💬 *Xe máy Đông Nam Á = phương tiện không giới hạn tải trọng. Luật giao thông ghi "chở tối đa 2 người" nhưng thực tế: thêm 1 cái tủ lạnh vẫn ok. Xe máy Việt Nam ngày Tết chở cây mai + quà Tết + 3 người — đó không phải vi phạm, đó là NGHỆ THUẬT 🎨*
+
+---
+
+### 2. Thái Lan — Xứ sở nụ cười 😊
+
+> 🌍 Nguồn gốc: Thái Lan | ⭐ Điểm: 37/40
+
+Người Thái nổi tiếng luôn cười. Du khách hỏi người Thái:
+
+— Anh có vui không?
+
+Người Thái: *cười* 😊
+
+— Công việc ổn không?
+
+*Cười* 😊
+
+— Kinh tế khó khăn không?
+
+*Cười* 😊
+
+— Anh... có chuyện buồn gì không?
+
+*Cười* 😊
+
+Du khách hoang mang:
+
+— Anh lúc nào cũng cười vậy à?
+
+Người Thái, vẫn cười:
+
+— Ở Thái Lan, khóc cũng không giải quyết được gì. Mà cười thì ĐƯỢC TIỀN TIP từ du khách. 😏
+
+> 😂💬 *"Xứ sở nụ cười" — cười vì vui, cười vì buồn, cười vì... du khách cho tiền tip khi thấy mình cười. Thực dụng mà duyên. Người Việt mình cũng hay cười khi gặp chuyện khó xử — nụ cười Á Đông: che giấu 1000 cảm xúc bên trong 🙂*
+
+---
+
+### 3. Philippines — Bão cũng phải vui 🌀
+
+> 🌍 Nguồn gốc: Philippines | ⭐ Điểm: 37/40
+
+Philippines mỗi năm hứng 20+ cơn bão. Người Philippines đối mặt bão kiểu:
+
+Bão cấp 1: "Gió mát nhỉ!" ☁️
+
+Bão cấp 3: "Thôi khỏi quạt hôm nay!" 💨
+
+Bão cấp 5: *selfie với bão, đăng Facebook* 🤳
+
+Siêu bão: *nấu mì gói, livestream, hát karaoke giữa bão* 🎤
+
+Du khách hoảng hốt:
+
+— Bão to vậy sao mọi người vẫn vui?!
+
+Người Philippines tỉnh bơ:
+
+— Nếu KHÓC thì bão có DỪNG không? Không. Vậy thì CƯỜI cho đỡ sợ, rồi bão qua thì DỌN NHÀ. Đơn giản. 😎
+
+> 😂💬 *Selfie với siêu bão + hát karaoke = tinh thần Philippines bất diệt. Người Việt mình cũng vậy — bão vào thì... vẫn lên mạng "check-in bão" trước đã. "Bão to quá, wifi tắt rồi" mới là thảm họa thật sự. Đông Nam Á đối mặt thiên tai: bằng nụ cười và mì gói 🍜*
+
+---
+
+### 4. Indonesia — Đất nước vạn đảo 🏝️
+
+> 🌍 Nguồn gốc: Indonesia | ⭐ Điểm: 35/40
+
+Indonesia có 17.000 hòn đảo. Một người Jakarta nói chuyện với bạn ở đảo xa:
+
+— Mày ơi, đến nhà tao chơi!
+
+— Ừ, nhưng nhà mày ở đảo JAVA, tao ở đảo SULAWESI. Phải đi máy bay 3 tiếng.
+
+— Rồi sao? Bay thôi!
+
+— Rồi từ sân bay đến nhà mày mất bao lâu?
+
+— À, kẹt xe Jakarta thêm... 4 TIẾNG nữa. 😐
+
+Bạn:
+
+— Vậy bay 3 tiếng NHANH HƠN đi từ sân bay về nhà mày! 💀
+
+— Đúng. Ở Jakarta, bay qua hòn đảo khác dễ hơn ĐI TỪ NHÀ ĐẾN SỞ LÀM.
+
+> 😂💬 *Bay 3 tiếng xuyên đảo nhanh hơn kẹt xe 4 tiếng trong thành phố — logic Jakarta. Sài Gòn, Hà Nội nghe chuyện này chắc đồng cảm: "đi từ quận 1 sang quận 7 có khi lâu hơn bay ra Đà Nẵng." Đông Nam Á và kẹt xe: chuyện muôn thuở 🚗*
+
+---
+
+### 5. Ăn cay — Cuộc chiến Đông Nam Á 🌶️
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 36/40
+
+Cuộc thi ăn cay giữa các nước Đông Nam Á:
+
+Thái Lan mang tom yum siêu cay. Ăn xong, mồ hôi ròng ròng nhưng mặt bình thản: "Nhạt." 🇹🇭
+
+Indonesia mang sambal cấp độ hỏa ngục. Ăn xong, mắt đỏ, vẫn tỉnh bơ: "Vừa miệng." 🇮🇩
+
+Malaysia mang nasi lemak đặc biệt cay. Ăn xong, ho sặc sụa nhưng gật đầu: "OK lah." 🇲🇾
+
+Đến lượt Việt Nam. Anh Việt không mang đồ cay. Anh mang ra... một hũ MẮM TÔM. Mở nắp. 😈
+
+Cả 3 nước ĐẦU HÀNG ngay lập tức.
+
+Thái Lan:
+
+— Chúng tôi thi ĂN CAY, không thi... NGỬI! 💀
+
+> 😂💬 *Cay thì thua Thái, nhưng "tấn công khứu giác" thì Việt Nam vô đối. Mắm tôm không cay nhưng MÙI của nó là vũ khí hóa học hợp pháp. Người Việt ăn mắm tôm: "thơm quá!" Người nước ngoài: "ai xả hóa chất?!" Chiến thuật bất đối xứng 🫡*
+
+---
+
+### 6. Singapore — Phạt là nghệ thuật 🚫
+
+> 🌍 Nguồn gốc: Singapore | ⭐ Điểm: 36/40
+
+Singapore phạt mọi thứ: xả rác phạt, nhai kẹo cao su phạt, quên xả toilet phạt, cho chim bồ câu ăn phạt.
+
+Du khách mới đến Singapore, hỏi hướng dẫn viên:
+
+— Ở đây có gì KHÔNG bị phạt không?
+
+Hướng dẫn viên suy nghĩ:
+
+— THỞ. Thở thì không bị phạt. 😐
+
+Du khách thở phào.
+
+Hướng dẫn viên:
+
+— Nhưng nếu anh thở ra MÙI DURIAN ở chỗ công cộng thì... CŨNG PHẠT. 😤
+
+> 😂💬 *Singapore phạt đến mức thở cũng phải cẩn thận — nhưng nhờ vậy mà sạch nhất thế giới. Ở Việt Nam xả rác thì... ai cũng xả, không ai phạt, ai phạt thì cũng kệ. Hai cực đối lập: Singapore quá nghiêm, VN quá thoải mái. Đâu đó ở giữa mới là cân bằng 🗑️*
+
+---
+
+### 7. Malaysia — Đa văn hóa ẩm thực 🍜
+
+> 🌍 Nguồn gốc: Malaysia | Điểm: 34/40
+
+Malaysia có 3 nền ẩm thực: Malay, Trung Hoa, Ấn Độ. Hỏi người Malaysia "món nào là quốc hồn quốc túy?" là MỜI CHIẾN TRANH.
+
+Người Malay: "Nasi lemak! Đó là linh hồn Malaysia!" 🍛
+
+Người Malaysia gốc Hoa: "Char kuey teow! Ngon nhất!" 🍝
+
+Người Malaysia gốc Ấn: "Roti canai! Không có roti canai thì không phải Malaysia!" 🫓
+
+3 người cãi nhau 2 tiếng. Cuối cùng, tất cả đồng ý MỘT THỨ:
+
+— Dù gì thì cũng ngon hơn đồ ăn SINGAPORE. 😏
+
+Singapore: *triggered* 💀
+
+> 😂💬 *3 nền văn hóa cãi nhau về ẩm thực nhưng đoàn kết khi "chung kẻ thù" — Singapore. Cuộc chiến ẩm thực Malaysia-Singapore giống Việt Nam tranh cãi phở Hà Nội vs phở Sài Gòn: cãi hoài không hết, nhưng gặp ai chê phở Việt thì ĐOÀN KẾT ngay 🇻🇳*
+
+---
+
+### 8. Myanmar — Nhẫn nại là siêu năng lực 🙏
+
+> 🌍 Nguồn gốc: Myanmar | Điểm: 33/40
+
+Ở Myanmar, internet từng rất chậm. Mở một trang web mất 10 phút. Tải ảnh mất 30 phút.
+
+Một người Myanmar nói với bạn Hàn Quốc:
+
+— Mạng 5G là gì?
+
+— Là tải phim 2 tiếng trong 5 giây!
+
+Người Myanmar sốc:
+
+— 5 GIÂY?! Vậy mày LÀM GÌ trong 9 tiếng 59 phút 55 giây CÒN LẠI?! 😐
+
+Bạn Hàn:
+
+— Ơ... xem phim?
+
+Người Myanmar:
+
+— Chán nhỉ. Tao thì mất 10 tiếng để tải, nên TẬN HƯỞNG mỗi pixel load ra. SƯỚNG hơn nhiều. 😏
+
+> 😂💬 *Tận hưởng từng pixel load — triết lý sống chậm bất đắc dĩ nhưng biến thành lợi thế. Ở Việt Nam thời internet dial-up cũng vậy: chờ ảnh load từ trên xuống, hồi hộp "ảnh gì đây?" — thú vị hơn 5G tải xong trước khi kịp nháy mắt 📡*
+
+---
+
+### 9. Thời tiết Đông Nam Á — Hai mùa 🌧️
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 35/40
+
+Ở châu Âu có 4 mùa: Xuân, Hạ, Thu, Đông.
+
+Ở Đông Nam Á có 2 mùa: NÓNG và NÓNG HƠN. 🔥
+
+(Bonus: mùa thứ 3: MƯA — nhưng vẫn NÓNG)
+
+Du khách châu Âu:
+
+— Mùa nào mát nhất ở đây?
+
+Người Thái:
+
+— 2 giờ sáng. 🌙
+
+— Ý tôi là THÁNG nào?
+
+— Không có tháng mát. Có tháng NÓNG, tháng NÓNG HƠN, và tháng NÓNG MUỐN CHẾT. 💀
+
+Du khách:
+
+— Vậy sao mọi người sống được?
+
+— Vì chúng tôi có ĐIỀU HÒA... trong SIÊU THỊ. Cả nhà vào siêu thị hóng mát miễn phí. 😎
+
+> 😂💬 *Đông Nam Á chỉ có 2 mùa: nóng và nóng hơn. Giải pháp: vào siêu thị hóng mát — đây là hoạt động giải trí quốc dân. Ở Việt Nam mùa hè cũng vậy: "đi Vincom hóng mát" không phải đi mua đồ, mà đi TẬN HƯỞNG ĐIỀU HÒA MIỄN PHÍ. Chiến thuật sống sót mùa hè: có wifi, có máy lạnh, có mì gói 🧊*
+
+---
+
+### 10. Karaoke — Tôn giáo Đông Nam Á 🎤
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 36/40
+
+Karaoke ở Đông Nam Á không phải giải trí — là NGHĨA VỤ QUỐC DÂN.
+
+Philippines: hát karaoke LÚC NÀO CŨNG ĐƯỢC — 6 giờ sáng, 12 giờ đêm, giữa bão cấp 5 🎤
+
+Thái Lan: hát karaoke VỪA NHẬU — sai tông kệ, quan trọng là vui 🍺
+
+Indonesia: hát karaoke CẢ LÀNG — loa công suất lớn, cả khu phố nghe 📢
+
+Việt Nam: hát karaoke ĐẾN KHI HÀNG XÓM GỌI CÔNG AN 🚔
+
+Một du khách hỏi:
+
+— Ở Đông Nam Á, hát dở thì sao?
+
+Người Philippines:
+
+— Hát dở? Đông Nam Á KHÔNG CÓ NGƯỜI HÁT DỞ. Chỉ có người hát... KHÁC TÔNG. 😏
+
+> 😂💬 *Karaoke Đông Nam Á: không có "hát dở", chỉ có "hát khác tông." Ở Việt Nam, karaoke là nghi lễ tâm linh — mỗi khi nhậu xong phải hát karaoke, mỗi khi buồn phải hát karaoke, mỗi khi vui cũng phải hát karaoke. Hát đến khi nào hàng xóm gọi 113 mới thôi 🎶*
+
+---
+
+### 11. Grab/Gojek — Siêu anh hùng Đông Nam Á 🦸
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 35/40
+
+Shipper Grab/Gojek ở Đông Nam Á là SIÊU ANH HÙNG thật sự:
+
+— Giao đồ ăn lúc 2 giờ sáng dưới mưa? OK ✅
+
+— Giao hàng qua 3 con hẻm, 2 ngõ cụt, 1 cầu khỉ? OK ✅
+
+— Mua giùm 1 bịch mắm, 2 quả chanh, 3 trái ớt ở chợ? OK ✅
+
+— Chở mèo đi khám bệnh? OK ✅
+
+Một khách đặt Grab giao... LỜI XIN LỖI cho bạn gái.
+
+Shipper đến, đưa cho cô gái tờ giấy, rồi quỳ xuống thay mặt anh kia:
+
+— Em ơi, anh ấy gửi lời xin lỗi. Anh ấy sai rồi. 😔
+
+Cô gái:
+
+— Anh shipper quỳ thật lòng hơn ANH ẤY. Em tha thứ. 💀
+
+> 😂💬 *Shipper Đông Nam Á: giao hàng, giao đồ ăn, giao cả LỜI XIN LỖI — và quỳ thật lòng hơn chính chủ. Ở Việt Nam, shipper Grab là "người hùng thầm lặng": mưa gió bão bùng vẫn "5 phút nữa em tới." Đánh giá 5 sao cho shipper — họ xứng đáng 🌟*
+
+---
+
+### 12. Thái Lan — Đất nước sabai sabai 🏖️
+
+> 🌍 Nguồn gốc: Thái Lan | Điểm: 33/40
+
+"Sabai sabai" trong tiếng Thái nghĩa là "thư thả, thoải mái, kệ đi."
+
+Sếp nước ngoài hỏi nhân viên Thái:
+
+— Deadline dự án ngày mai. Xong chưa?
+
+— Sabai sabai, sếp ơi! 😊
+
+— Tức là XONG rồi?
+
+— Sabai sabai! 😊
+
+— Hay CHƯA xong?
+
+— Sabai sabai! 😊
+
+Sếp:
+
+— ANH TRẢ LỜI RÕ RÀNG ĐI!
+
+Nhân viên Thái, vẫn cười:
+
+— Sếp ơi, sabai sabai đi. Deadline là do CON NGƯỜI tạo ra. Mà con người thì LINH HOẠT. 😏
+
+> 😂💬 *"Deadline là do con người tạo ra" — triết lý sabai sabai phá vỡ mọi quy tắc công sở. Ở Việt Nam mình cũng có câu tương tự: "từ từ rồi tính" — deadline sáng mai nhưng "từ từ" vẫn là câu trả lời. Đông Nam Á và deadline: mối quan hệ phức tạp 📆*
+
+---
+
+### 13. Durian — Vua trái cây gây chia rẽ 🤢
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 36/40
+
+Durian (sầu riêng) — trái cây chia thế giới thành 2 phe:
+
+Phe YÊU (Đông Nam Á): "Ngon nhất trần đời! Thơm lừng! Béo ngậy! Vua trái cây!" 😍
+
+Phe GHÉT (phần còn lại): "AI ĐỂ XÁC CHẾT TRONG PHÒNG?!" 🤮
+
+Khách sạn Singapore cấm mang durian vào. Sân bay cấm. Tàu điện cấm. Biển cấm durian nhiều hơn biển cấm hút thuốc.
+
+Một ông Thái mang durian lên máy bay. Tiếp viên:
+
+— Thưa ông, không được mang durian!
+
+Ông Thái:
+
+— Nhưng đây là MUSANG KING, 1 triệu đồng/kg! Đắt hơn vé MÁY BAY!
+
+Tiếp viên:
+
+— Vâng, nhưng nếu ông mở ra thì CẢ MÁY BAY sẽ muốn nhảy dù. 😐💀
+
+> 😂💬 *Sầu riêng — trái cây duy nhất bị CẤM ở sân bay, khách sạn, tàu điện. Giá đắt hơn vé máy bay nhưng mùi khiến cả phi cơ muốn nhảy dù. Ở Việt Nam, sầu riêng được yêu cuồng nhiệt — "mùa sầu riêng" là mùa lễ hội quốc dân. Ai chê sầu riêng = kẻ thù toàn Đông Nam Á 🫡*
+
+---
+
+### 14. Giao thông Đông Nam Á — Luật bất thành văn 🚦
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 35/40
+
+Luật giao thông Đông Nam Á viết trong sách: đèn đỏ dừng, đèn xanh đi, đèn vàng chuẩn bị.
+
+Luật giao thông Đông Nam Á THỰC TẾ:
+
+— Đèn đỏ: "Gợi ý dừng" (nếu không có cảnh sát) 🔴
+
+— Đèn xanh: "Đi nhanh trước khi đèn đỏ!" 🟢
+
+— Đèn vàng: "TĂNG TỐC!" 🟡
+
+— Bóp còi: dùng thay PHANH 📣
+
+— Kính chiếu hậu: dùng để SỬA TÓC 💇
+
+Du khách lái xe ở Đông Nam Á lần đầu, về nhà kể:
+
+— Tôi đã trải qua 10 phút lái xe nguy hiểm nhất đời.
+
+Người bản địa:
+
+— 10 phút? Anh mới ra khỏi BÃI ĐỖ thôi mà! 😂
+
+> 😂💬 *Đèn đỏ = "gợi ý", bóp còi = thay phanh, kính chiếu hậu = soi gương — bộ luật giao thông bất thành văn Đông Nam Á. Ở Việt Nam đặc biệt: vượt đèn đỏ nhưng vẫn BÓP CÒI cảnh báo người đi đúng luật tránh. Logic ngược nhưng somehow... hiệu quả 🤷*
+
+---
+
+### 15. Philippines — Tiếng Anh nửa mùa 🗣️
+
+> 🌍 Nguồn gốc: Philippines | Điểm: 34/40
+
+Người Philippines nói tiếng Anh rất giỏi — nhưng hay trộn tiếng Tagalog, tạo ra "Taglish":
+
+— "I'm going sa market to buy mga vegetables." (Tao đi chợ mua rau)
+
+— "Can you paki-open yung door?" (Mở cửa giùm?)
+
+— "Ang traffic naman today!" (Kẹt xe quá hôm nay!)
+
+Người Mỹ nghe Taglish:
+
+— Tôi hiểu tiếng Anh, nhưng CÂU NÀY tôi không hiểu từ nào.
+
+Người Philippines:
+
+— Sir, that's because it's not English. It's TAGLISH — the SUPERIOR language! 😎
+
+> 😂💬 *Taglish — tiếng Anh pha Tagalog, chỉ người Philippines hiểu. Ở Việt Nam cũng có "Vietlish": "Ok fine, để tao handle cái task này, deadline ngày mai nha, sẽ update qua email." Trộn ngôn ngữ = siêu năng lực Đông Nam Á 🗣️*
+
+---
+
+### 16. Nước mắm — Vũ khí bí mật Việt Nam 🐟
+
+> 🌍 Nguồn gốc: Đông Nam Á (Việt Nam focus) | ⭐ Điểm: 37/40
+
+Hội nghị ẩm thực Đông Nam Á. Mỗi nước mang gia vị đặc trưng:
+
+Thái Lan: nước mắm + ớt + chanh = dipping sauce hoàn hảo 🇹🇭
+
+Indonesia: sambal — tương ớt cay xé lưỡi 🇮🇩
+
+Malaysia: belacan — mắm tôm Malaysia 🇲🇾
+
+Việt Nam: NƯỚC MẮM NGUYÊN CHẤT. Mở nắp. 🇻🇳
+
+Phòng họp sơ tán trong 30 giây. 💨
+
+Đại biểu Nhật Bản (đã quen với nattō) bình tĩnh ngồi lại:
+
+— Mùi này... quen quen. 😐
+
+Đại biểu Việt Nam:
+
+— Anh ơi, đây mới là loại NHẠT. Để tôi mở loại Phú Quốc 40 ĐỘ ĐẠM...
+
+Đại biểu Nhật cũng sơ tán. 💀
+
+> 😂💬 *Nước mắm Phú Quốc 40 độ đạm — vũ khí hủy diệt hàng loạt dưới dạng gia vị. Cả hội nghị sơ tán chỉ trừ người Nhật (quen nattō) nhưng khi mở loại premium thì Nhật cũng chào thua. Người Việt: "mùi thơm mà, sao ai cũng chạy?" Thế giới: "THƠM?!" 🤣*
+
+---
+
+### 17. Tết Songkran — Lễ hội té nước Thái Lan 💦
+
+> 🌍 Nguồn gốc: Thái Lan | ⭐ Điểm: 35/40
+
+Tết Songkran ở Thái Lan — cả nước TÉ NƯỚC vào nhau.
+
+Du khách lần đầu đến Thái vào dịp Songkran, mặc đồ đẹp ra phố.
+
+5 giây sau: ƯỚT NHƯ CHUỘT 💦
+
+Anh ta hỏi người Thái:
+
+— Tại sao té nước vào tôi?! Tôi không tham gia!
+
+Người Thái cười:
+
+— Songkran KHÔNG CẦN ĐĂNG KÝ. Ra đường là THAM GIA. 😊🔫
+
+Du khách:
+
+— Nhưng tôi mặc đồ vest, đi họp công ty!
+
+Người Thái:
+
+— Sếp anh cũng đang BỊ TÉ NƯỚC ngoài kia rồi! Sabai sabai! 💀
+
+> 😂💬 *Songkran không cần đăng ký — ra đường = tự động tham gia. Sếp mặc vest cũng bị té nước. Ở Việt Nam mình cũng có lễ hội vui tương tự — Tết Nguyên Đán: "ra đường là BỊ CHÚC TẾT, không trốn được." Đông Nam Á: lễ hội = bắt buộc tham gia 🎊*
+
+---
+
+### 18. Cà phê Đông Nam Á ☕
+
+> 🌍 Nguồn gốc: Đông Nam Á | Điểm: 34/40
+
+Cà phê ở các nước Đông Nam Á:
+
+Việt Nam: cà phê sữa đá — ĐẬM, ĐẶC, NGỌT, uống xong TIM ĐÁNH TRỐNG 🫀
+
+Thái Lan: Thai iced coffee — ngọt + kem + sữa đặc = TRÁNG MIỆNG giả dạng cà phê 🍦
+
+Indonesia: kopi tubruk — cà phê + nước nóng, BÃ ĐẦY CỐC, uống phải lọc bằng răng 🦷
+
+Philippines: 3-in-1 instant coffee — "gói đây, nước sôi đây, XONG." ⚡
+
+Du khách uống thử cà phê Việt Nam lần đầu:
+
+— TRỜI ƠI, tim tao đập 200 nhịp/phút!
+
+Người Việt:
+
+— Bình thường. Đó là ly THỨ NHẤT. Người Việt uống 5 LY/NGÀY. 😐
+
+> 😂💬 *Cà phê Việt Nam đậm đến mức du khách uống 1 ly thì tim muốn nổ. Người Việt uống 5 ly/ngày vẫn ngủ ngon — đã miễn dịch caffeine từ nhỏ. So với cà phê Starbucks thì cà phê Việt Nam mạnh gấp 10 lần, rẻ gấp 10 lần, và ngon gấp... 100 lần (theo người Việt) ☕*
+
+---
+
+### 19. Xe tuk-tuk và giá du khách 🛺
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 35/40
+
+Du khách lên xe tuk-tuk ở Bangkok:
+
+— Khách sạn ABC bao nhiêu?
+
+Tài xế:
+
+— 500 baht!
+
+— Nhưng đó chỉ cách 1km!
+
+— 500 baht, có bao gồm TRẢI NGHIỆM VĂN HÓA. 😊
+
+Du khách:
+
+— Grab nói 60 baht.
+
+Tài xế im lặng. Rồi:
+
+— 100 baht. Nhưng tôi đưa anh đi ĐƯỜNG ĐẸP.
+
+— 80 baht.
+
+— 80 baht... nhưng anh phải CHỤP ẢNH với xe tuk-tuk của tôi đăng Instagram.
+
+Du khách:
+
+— Deal! 🤝
+
+Tài xế nghĩ: *"Lại thêm 1 người quảng cáo miễn phí cho mình."* 😏
+
+> 😂💬 *Giá du khách → giá Grab → giá trả với điều kiện chụp ảnh Instagram = marketing miễn phí. Tài xế tuk-tuk Bangkok là doanh nhân thông minh — dùng du khách làm influencer. Ở Việt Nam, xích lô Hà Nội cũng y chang: "anh chụp ảnh đăng Facebook giùm, giảm 50%!" 📸*
+
+---
+
+### 20. Đông Nam Á — Khi cả khu vực họp mặt 🌏
+
+> 🌍 Nguồn gốc: Đông Nam Á | ⭐ Điểm: 37/40
+
+Hội nghị ASEAN. 10 nước ngồi cùng bàn:
+
+— Thái Lan: "Sabai sabai, bắt đầu khi nào cũng được." 😊
+
+— Singapore: "Bắt đầu ĐÚNG GIỜ, tôi đã lên lịch từ 3 tuần trước." ⏰
+
+— Philippines: "Tôi mang karaoke machine, ai hát trước?" 🎤
+
+— Indonesia: "Tôi mang sambal, ai ăn cay?" 🌶️
+
+— Việt Nam: "Tôi mang nước mắm — ai dám?" 😈
+
+— Malaysia: "Tất cả các món kia đều là của MALAYSIA gốc." 🇲🇾
+
+— Myanmar: "Internet chậm, tôi mới nhận tin mời hôm nay." 📡
+
+— Lào: "Tôi đến rồi nhưng ngồi yên, sabai sabai." 😌
+
+— Cambodia: "Tôi mang Angkor Wat miniature làm quà." 🏛️
+
+— Brunei: "Tôi trả tiền bữa ăn cho tất cả." 💰
+
+Cả bàn: "BRUNEI NÓI GÌ?! LẶP LẠI ĐI!" 😂
+
+> 😂💬 *10 nước ASEAN ngồi cùng bàn — mỗi nước một tính cách: Thái sabai, Singapore nghiêm túc, Philippines karaoke, Việt Nam mang nước mắm "gây chiến," Malaysia nhận vơ, Brunei trả tiền. Đông Nam Á đa dạng nhưng có chung 1 thứ: TÌNH HÀNG XÓM — cãi nhau xong vẫn ăn cùng bàn, cười cùng nhau 🤝*
+
+---
+
+📊 **Thống kê chương:** 20 truyện | Điểm trung bình: 35.3/40 | Truyện ⭐: 13


### PR DESCRIPTION
## Summary
- Tổng hợp và Việt hóa **20 truyện cười Đông Nam Á** cho Chương 14
- Bao gồm truyện từ: Thái Lan, Philippines, Indonesia, Singapore, Malaysia, Myanmar, Việt Nam
- Chủ đề: xe máy vạn năng, nụ cười Thái, bão Philippines, kẹt xe Jakarta, ăn cay, phạt Singapore, durian, karaoke quốc dân, Grab/Gojek, nước mắm, Songkran, ASEAN họp mặt
- **20/20 truyện đạt** (≥ 30/40), **15 truyện ⭐** (≥ 35/40), **0 loại**
- Điểm trung bình: 35.3/40
- Truyện hay nhất: "Xe máy Đông Nam Á" (38/40)

## Files changed
- `sach/14-truyen-cuoi-dong-nam-a.md` — nội dung chương
- `metadata/scoring-log.md` — bảng chấm điểm
- `CHANGELOG.md` — nhật ký thay đổi

## Test plan
- [ ] Kiểm tra format Markdown nhất quán
- [ ] Kiểm tra scoring đúng tiêu chí
- [ ] Kiểm tra Việt hóa phù hợp
- [ ] Kiểm tra không trùng truyện với chương khác
- [ ] Kiểm tra đại diện đều các nước ASEAN

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)