### PR TITLE
🚀 Tạo website đọc online (mdBook + GitHub Pages)

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -1,0 +1,45 @@
+name: Deploy mdBook to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+
+      - name: Build book
+        run: mdbook build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Output files
 full-book.md
+docs/
 *.pdf
 *.epub
 *.docx

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,22 @@
+[book]
+title = "CƯỜI VỠ BỤNG — Tuyển Tập Truyện Cười Thế Giới Cho Người Việt"
+authors = ["Tung Tran"]
+description = "331 truyện cười từ 15 quốc gia, Việt hóa cho người Việt"
+language = "vi"
+src = "sach"
+
+[build]
+build-dir = "docs"
+
+[output.html]
+default-theme = "light"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/trananhtung/vietnamese-joke-book"
+edit-url-template = "https://github.com/trananhtung/vietnamese-joke-book/edit/main/sach/{path}"
+no-section-label = false
+additional-css = ["theme/custom.css"]
+
+[output.html.search]
+enable = true
+limit-results = 30
+use-hierarchical-headings = true

--- a/sach/SUMMARY.md
+++ b/sach/SUMMARY.md
@@ -1,0 +1,38 @@
+# Mục Lục
+
+[Lời nói đầu](./00-loi-noi-dau.md)
+
+---
+
+# Phần I: Phương Tây
+
+- [Chương 01: Truyện Cười Mỹ 🇺🇸](./01-truyen-cuoi-my.md)
+- [Chương 02: Truyện Cười Anh 🇬🇧](./02-truyen-cuoi-anh.md)
+- [Chương 03: Truyện Cười Pháp 🇫🇷](./03-truyen-cuoi-phap.md)
+- [Chương 04: Truyện Cười Đức 🇩🇪](./04-truyen-cuoi-duc.md)
+- [Chương 05: Truyện Cười Nga 🇷🇺](./05-truyen-cuoi-nga.md)
+- [Chương 13: Truyện Cười Bắc Âu 🧊](./13-truyen-cuoi-bac-au.md)
+- [Chương 15: Truyện Cười Úc & New Zealand 🦘](./15-truyen-cuoi-uc.md)
+
+# Phần II: Châu Á
+
+- [Chương 06: Truyện Cười Nhật Bản 🇯🇵](./06-truyen-cuoi-nhat.md)
+- [Chương 07: Truyện Cười Hàn Quốc 🇰🇷](./07-truyen-cuoi-han.md)
+- [Chương 08: Truyện Cười Trung Quốc 🇨🇳](./08-truyen-cuoi-trung.md)
+- [Chương 09: Truyện Cười Ấn Độ 🇮🇳](./09-truyen-cuoi-an-do.md)
+- [Chương 14: Truyện Cười Đông Nam Á 🌏](./14-truyen-cuoi-dong-nam-a.md)
+
+# Phần III: Trung Đông, Châu Phi & Mỹ Latin
+
+- [Chương 10: Truyện Cười Trung Đông 🐪](./10-truyen-cuoi-trung-dong.md)
+- [Chương 11: Truyện Cười Châu Phi 🌍](./11-truyen-cuoi-chau-phi.md)
+- [Chương 12: Truyện Cười Mỹ Latin 🌎](./12-truyen-cuoi-my-latin.md)
+
+# Phần IV: Tổng Hợp
+
+- [Chương 16: Truyện Cười Quốc Tế 🌐](./16-truyen-cuoi-quoc-te.md)
+- [Chương 17: Bonus — Truyện Cười Kinh Điển 🏆](./17-bonus-truyen-cuoi-kinh-dien.md)
+
+---
+
+[Lời kết](./99-loi-ket.md)

--- a/theme/custom.css
+++ b/theme/custom.css
@@ -1,0 +1,50 @@
+/* Custom CSS for Cười Vỡ Bụng mdBook */
+
+/* Better Vietnamese font rendering */
+:root {
+  --content-max-width: 820px;
+}
+
+body {
+  font-family: 'Noto Sans', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+/* Joke styling - blockquotes */
+blockquote {
+  border-left: 4px solid #f0ad4e;
+  background: #fff9e6;
+  padding: 0.8em 1em;
+  margin: 1em 0;
+  border-radius: 0 8px 8px 0;
+}
+
+.ayu blockquote,
+.coal blockquote,
+.navy blockquote {
+  background: rgba(240, 173, 78, 0.1);
+}
+
+/* Story headers */
+h3 {
+  margin-top: 2em;
+  padding-top: 1em;
+  border-top: 1px solid #eee;
+}
+
+.ayu h3,
+.coal h3,
+.navy h3 {
+  border-top-color: #333;
+}
+
+/* Horizontal rules between jokes */
+hr {
+  border: none;
+  border-top: 2px dashed #ddd;
+  margin: 2em 0;
+}
+
+/* Stats line at bottom of chapters */
+p:last-of-type strong {
+  color: #d9534f;
+}


### PR DESCRIPTION
## Summary
- Setup **mdBook** để build sách thành static website
- Tổ chức mục lục theo vùng miền (Phương Tây, Châu Á, Trung Đông/Phi/Latin, Tổng hợp)
- Custom CSS cho blockquote (nguồn gốc truyện), joke separators
- **GitHub Actions** auto-deploy lên GitHub Pages khi push to main
- Hỗ trợ search, responsive mobile, dark mode

## Files
- `book.toml` — cấu hình mdBook
- `sach/SUMMARY.md` — mục lục cho mdBook
- `theme/custom.css` — styling tùy chỉnh
- `.github/workflows/deploy-mdbook.yml` — CI/CD deploy
- `.gitignore` — thêm `docs/`

## Setup
Cần bật GitHub Pages trong Settings → Pages → Source: GitHub Actions

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated documentation site deployment to GitHub Pages using mdBook.
  * Vietnamese documentation structure with organized table of contents.
  * Custom styling and formatting applied to documentation pages.
  * Continuous integration workflow for building and publishing documentation on push to main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->